### PR TITLE
Fixed Arduino Example Header

### DIFF
--- a/examples/mnist_arduino/tm_port.h
+++ b/examples/mnist_arduino/tm_port.h
@@ -13,7 +13,7 @@ limitations under the License.
 #ifndef __TM_PORT_H
 #define __TM_PORT_H
 
-#include "arduino.h"
+#include <Arduino.h>
 
 #define TM_ARCH_OPT0        (0) //default
 #define TM_ARCH_OPT1        (1)


### PR DESCRIPTION
mnist_arduino example not compiling in Arduino IDE.

Fixed by changing include header, working as expected without errors now.