### PR TITLE
Fix typo issue, add local exp() functions _exp() instead of link libm

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ TM_INLINE void tm_dot_prod(mtype_t* sptr, mtype_t* kptr,uint32_t size, sumtype_t
 ...
 
 ## Contribution & Contacts
-If you want contribute fucntions to TinyMaix, please read "TinyMaix Design" sections, we only want functions in "Features in design" and "Features maybe added".  
+If you want contribute functions to TinyMaix, please read "TinyMaix Design" sections, we only want functions in "Features in design" and "Features maybe added".  
 
 If you want commit your port test result, please commit to benchmark.md.
 You are welcome to port TinyMaix to your chip/boards, it will prove how easy to use TinyMaix run Deeplearning model in MCUs~

--- a/examples/maixhub_detection_yolov2/include/tinymaix.h
+++ b/examples/maixhub_detection_yolov2/include/tinymaix.h
@@ -279,14 +279,14 @@ typedef tm_err_t (*tm_cb_t)(tm_mdl_t* mdl, tml_head_t* lh);
 /******************************* GLOBAL VARIABLE ************************************/
 
 
-/******************************* MODEL FUCNTION ************************************/
+/******************************* MODEL FUNCTION ************************************/
 tm_err_t tm_load  (tm_mdl_t* mdl, const uint8_t* bin, uint8_t*buf, tm_cb_t cb, tm_mat_t* in);   //load model
 void     tm_unload(tm_mdl_t* mdl);                                      //remove model
 tm_err_t tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_mat_t* in, tm_mat_t* out);            //preprocess input data
 tm_err_t tm_run   (tm_mdl_t* mdl, tm_mat_t* in, tm_mat_t* out);         //run model
 
 
-/******************************* LAYER FUCNTION ************************************/
+/******************************* LAYER FUNCTION ************************************/
 tm_err_t tml_conv2d_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype_t* b, \
     int kw, int kh, int sx, int sy, int dx, int dy, int act, \
     int pad_top, int pad_bottom, int pad_left, int pad_right, int dmul, \
@@ -298,12 +298,12 @@ tm_err_t tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp,
 tm_err_t tml_reshape(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp, sctype_t out_s, zptype_t out_zp);
 
 
-/******************************* STAT FUCNTION ************************************/
+/******************************* STAT FUNCTION ************************************/
 #if TM_ENABLE_STAT
 tm_err_t tm_stat(tm_mdlbin_t* mdl);                    //stat model
 #endif
 
-/******************************* UTILS FUCNTION ************************************/
+/******************************* UTILS FUNCTION ************************************/
 uint8_t __attribute__((weak)) tm_fp32to8(float fp32);
 float __attribute__((weak)) tm_fp8to32(uint8_t fp8);
 

--- a/examples/maixhub_image_classification/include/tinymaix.h
+++ b/examples/maixhub_image_classification/include/tinymaix.h
@@ -279,14 +279,14 @@ typedef tm_err_t (*tm_cb_t)(tm_mdl_t* mdl, tml_head_t* lh);
 /******************************* GLOBAL VARIABLE ************************************/
 
 
-/******************************* MODEL FUCNTION ************************************/
+/******************************* MODEL FUNCTION ************************************/
 tm_err_t tm_load  (tm_mdl_t* mdl, const uint8_t* bin, uint8_t*buf, tm_cb_t cb, tm_mat_t* in);   //load model
 void     tm_unload(tm_mdl_t* mdl);                                      //remove model
 tm_err_t tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_mat_t* in, tm_mat_t* out);            //preprocess input data
 tm_err_t tm_run   (tm_mdl_t* mdl, tm_mat_t* in, tm_mat_t* out);         //run model
 
 
-/******************************* LAYER FUCNTION ************************************/
+/******************************* LAYER FUNCTION ************************************/
 tm_err_t tml_conv2d_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype_t* b, \
     int kw, int kh, int sx, int sy, int dx, int dy, int act, \
     int pad_top, int pad_bottom, int pad_left, int pad_right, int dmul, \
@@ -298,12 +298,12 @@ tm_err_t tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp,
 tm_err_t tml_reshape(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp, sctype_t out_s, zptype_t out_zp);
 
 
-/******************************* STAT FUCNTION ************************************/
+/******************************* STAT FUNCTION ************************************/
 #if TM_ENABLE_STAT
 tm_err_t tm_stat(tm_mdlbin_t* mdl);                    //stat model
 #endif
 
-/******************************* UTILS FUCNTION ************************************/
+/******************************* UTILS FUNCTION ************************************/
 uint8_t __attribute__((weak)) tm_fp32to8(float fp32);
 float __attribute__((weak)) tm_fp8to32(uint8_t fp8);
 

--- a/examples/mnist_arduino/tinymaix.h
+++ b/examples/mnist_arduino/tinymaix.h
@@ -244,14 +244,14 @@ typedef tm_err_t (*tm_cb_t)(tm_mdl_t* mdl, tml_head_t* lh);
 /******************************* GLOBAL VARIABLE ************************************/
 
 
-/******************************* MODEL FUCNTION ************************************/
+/******************************* MODEL FUNCTION ************************************/
 tm_err_t tm_load  (tm_mdl_t* mdl, const uint8_t* bin, uint8_t*buf, tm_cb_t cb, tm_mat_t* in);   //load model
 void     tm_unload(tm_mdl_t* mdl);                                      //remove model
 tm_err_t tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_mat_t* in, tm_mat_t* out);            //preprocess input data
 tm_err_t tm_run   (tm_mdl_t* mdl, tm_mat_t* in, tm_mat_t* out);         //run model
 
 
-/******************************* LAYER FUCNTION ************************************/
+/******************************* LAYER FUNCTION ************************************/
 tm_err_t tml_conv2d_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype_t* b, \
     int kw, int kh, int sx, int sy, int dx, int dy, int act, \
     int pad_top, int pad_bottom, int pad_left, int pad_right, int dmul, \
@@ -263,7 +263,7 @@ tm_err_t tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp,
 tm_err_t tml_reshape(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp, sctype_t out_s, zptype_t out_zp);
 
 
-/******************************* STAT FUCNTION ************************************/
+/******************************* STAT FUNCTION ************************************/
 #if TM_ENABLE_STAT
 tm_err_t tm_stat(tm_mdlbin_t* mdl);                    //stat model
 #endif

--- a/include/tinymaix.h
+++ b/include/tinymaix.h
@@ -279,14 +279,14 @@ typedef tm_err_t (*tm_cb_t)(tm_mdl_t* mdl, tml_head_t* lh);
 /******************************* GLOBAL VARIABLE ************************************/
 
 
-/******************************* MODEL FUCNTION ************************************/
+/******************************* MODEL FUNCTION ************************************/
 tm_err_t tm_load  (tm_mdl_t* mdl, const uint8_t* bin, uint8_t*buf, tm_cb_t cb, tm_mat_t* in);   //load model
 void     tm_unload(tm_mdl_t* mdl);                                      //remove model
 tm_err_t tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_mat_t* in, tm_mat_t* out);            //preprocess input data
 tm_err_t tm_run   (tm_mdl_t* mdl, tm_mat_t* in, tm_mat_t* out);         //run model
 
 
-/******************************* LAYER FUCNTION ************************************/
+/******************************* LAYER FUNCTION ************************************/
 tm_err_t tml_conv2d_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype_t* b, \
     int kw, int kh, int sx, int sy, int dx, int dy, int act, \
     int pad_top, int pad_bottom, int pad_left, int pad_right, int dmul, \
@@ -298,12 +298,12 @@ tm_err_t tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp,
 tm_err_t tml_reshape(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp, sctype_t out_s, zptype_t out_zp);
 
 
-/******************************* STAT FUCNTION ************************************/
+/******************************* STAT FUNCTION ************************************/
 #if TM_ENABLE_STAT
 tm_err_t tm_stat(tm_mdlbin_t* mdl);                    //stat model
 #endif
 
-/******************************* UTILS FUCNTION ************************************/
+/******************************* UTILS FUNCTION ************************************/
 uint8_t __attribute__((weak)) tm_fp32to8(float fp32);
 float __attribute__((weak)) tm_fp8to32(uint8_t fp8);
 

--- a/include/tinymaix.h
+++ b/include/tinymaix.h
@@ -319,4 +319,20 @@ float __attribute__((weak)) tm_fp8to32(uint8_t fp8);
     #define TML_DEQUANT(lh, x)       ((float)(x))
 #endif
 
+/******************************* LOCAL_EXP FUNCTION  ************************************/
+#if TM_LOCAL_EXP
+inline float _exp(float x) {
+    float p = 1.442695040f * x;
+    uint32_t i = 0;
+    uint32_t sign = (i >> 31);
+    int w = (int) p;
+    float z = p - (float) w + (float) sign;
+    union {
+        uint32_t i;
+        float f;
+    } v = {.i = (uint32_t) ((1 << 23) * (p + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z))};
+    return v.f;
+}
+#endif
+
 #endif 

--- a/include/tm_port.h
+++ b/include/tm_port.h
@@ -33,6 +33,7 @@ limitations under the License.
 #define TM_MAX_CSIZE    (1000)      //max channel num //used if INT8 mdl  //cost TM_MAX_CSIZE*4 Byte
 #define TM_MAX_KSIZE    (5*5)       //max kernel_size   //cost TM_MAX_KSIZE*4 Byte
 #define TM_MAX_KCSIZE   (3*3*256)   //max kernel_size*channels //cost TM_MAX_KSIZE*sizeof(mtype_t) Byte
+#define TM_LOCAL_EXP    0           //use local exp() func
 
 #define TM_INLINE       __attribute__((always_inline)) static inline
 #define tm_malloc(x)    malloc(x)

--- a/src/tm_layers.c
+++ b/src/tm_layers.c
@@ -299,7 +299,11 @@ tm_err_t __attribute__((weak)) tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t
     float sum = 0;
     for(int c=0; c <in->c; c++){
         dout[c] -= dmax;
+#if TM_LOCAL_EXP
+        dout[c] = (float)_exp(dout[c]);
+#else
         dout[c] = (float)exp(dout[c]);
+#endif
         sum     += dout[c];
         dout[c] -= 0.000001;  //prevent 1.0 value (cause 256 overflow)
     }

--- a/src/tm_layers_O1.c
+++ b/src/tm_layers_O1.c
@@ -779,7 +779,11 @@ tm_err_t __attribute__((weak)) tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t
     float sum = 0;
     for(int c=0; c <in->c; c++){
         dout[c] -= dmax;
+#if TM_LOCAL_EXP
+        dout[c] = (float)_exp(dout[c]);
+#else
         dout[c] = (float)exp(dout[c]);
+#endif
         sum     += dout[c];
         dout[c] -= 0.000001;  //prevent 1.0 value (cause 256 overflow)
     }

--- a/src/tm_layers_fp8.c
+++ b/src/tm_layers_fp8.c
@@ -129,7 +129,11 @@ tm_err_t tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_t in_zp,
     float sum = 0;
     for(int c=0; c <in->c; c++){
         dout[c] -= dmax;
+#if TM_LOCAL_EXP
+        dout[c] = (float)_exp(dout[c]);
+#else
         dout[c] = (float)exp(dout[c]);
+#endif
         sum     += dout[c];
         //dout[c] -= 0.000000001;  //prevent 1.0 value (cause 256 overflow)
     }


### PR DESCRIPTION
1. `FUCNTION` -> `FUNCTION`
2. Add `TM_LOCAL_EXP` to enable local `exp()` function, for bare metal applications that cannot link libm and libc