### PR TITLE
Separate `__attribute__((weak))` from source, standardize CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
-set(TARGET_NAME tinymaix)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(tinymaix)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
@@ -11,5 +14,4 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 " CACHE STRING "c++ flags")
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/src lib_tinymaix) 
 include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-add_library(${TARGET_NAME} STATIC ${lib_tinymaix})
-
+add_library(${PROJECT_NAME} STATIC ${lib_tinymaix})

--- a/examples/cifar10/CMakeLists.txt
+++ b/examples/cifar10/CMakeLists.txt
@@ -1,20 +1,22 @@
-set(TARGET_NAME cifar10)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(cifar10)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 " )
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 " )
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 ")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
-
-include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} main.c ${lib_tinymaix} )  
-target_link_libraries(${TARGET_NAME} -lm )   
+add_executable(${PROJECT_NAME} main.c ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)

--- a/examples/kws/CMakeLists.txt
+++ b/examples/kws/CMakeLists.txt
@@ -1,7 +1,10 @@
-set(TARGET_NAME kws)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(kws)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
@@ -9,12 +12,11 @@ set(CMAKE_STRIP "strip")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os ")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os ")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
-
-include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} main.c mel_test.c ${lib_tinymaix} )  
-target_link_libraries(${TARGET_NAME} -lm )   
+add_executable(${PROJECT_NAME} main.c mel_test.c ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)

--- a/examples/layer_test/CMakeLists.txt
+++ b/examples/layer_test/CMakeLists.txt
@@ -1,7 +1,10 @@
-set(TARGET_NAME layer_test)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(layer_test)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
@@ -9,12 +12,11 @@ set(CMAKE_STRIP "strip")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 " CACHE STRING "c flags")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 " CACHE STRING "c++ flags")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
-
-include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} main.c ${lib_tinymaix} )  
-target_link_libraries(${TARGET_NAME} -lm )   
+add_executable(${PROJECT_NAME} main.c ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)

--- a/examples/maixhub_detection_yolov2/CMakeLists.txt
+++ b/examples/maixhub_detection_yolov2/CMakeLists.txt
@@ -1,7 +1,10 @@
-set(TARGET_NAME yolov2)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(yolov2)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
@@ -9,8 +12,7 @@ set(CMAKE_STRIP "strip")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os " CACHE STRING "c flags")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os " CACHE STRING "c++ flags")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
-
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
@@ -19,5 +21,5 @@ aux_source_directory(. srcs)
 
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} ${srcs} ${lib_tinymaix} )
-target_link_libraries(${TARGET_NAME} -lm )
+add_executable(${PROJECT_NAME} ${srcs} ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)

--- a/examples/maixhub_image_classification/CMakeLists.txt
+++ b/examples/maixhub_image_classification/CMakeLists.txt
@@ -1,7 +1,10 @@
-set(TARGET_NAME classification)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(classification)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
@@ -9,15 +12,13 @@ set(CMAKE_STRIP "strip")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os " CACHE STRING "c flags")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os " CACHE STRING "c++ flags")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
-
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
 aux_source_directory(. srcs)
-
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} ${srcs} ${lib_tinymaix} )
-target_link_libraries(${TARGET_NAME} -lm )
+add_executable(${PROJECT_NAME} ${srcs} ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)

--- a/examples/mbnet/CMakeLists.txt
+++ b/examples/mbnet/CMakeLists.txt
@@ -1,7 +1,10 @@
-set(TARGET_NAME mbnet)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(mbnet)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
@@ -9,15 +12,14 @@ set(CMAKE_STRIP "strip")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 ")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 ")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
-
-include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} main.c label.c ${lib_tinymaix} )  
-target_link_libraries(${TARGET_NAME} -lm )   
+add_executable(${PROJECT_NAME} main.c label.c ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)
 
 
 

--- a/examples/mnist/CMakeLists.txt
+++ b/examples/mnist/CMakeLists.txt
@@ -1,20 +1,22 @@
-set(TARGET_NAME mnist)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(mnist)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 " )
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 " )
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 ")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
-
-include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} main.c ${lib_tinymaix} )  
-target_link_libraries(${TARGET_NAME} -lm )   
+add_executable(${PROJECT_NAME} main.c ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)

--- a/examples/vww/CMakeLists.txt
+++ b/examples/vww/CMakeLists.txt
@@ -1,20 +1,21 @@
-set(TARGET_NAME vww)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
+
+project(vww)
+
 set(CMAKE_AR "ar")
 set(CMAKE_RANLIB "ranlib")
 set(CMAKE_STRIP "strip")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 " )
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 " )
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 ")
 
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix) 
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../../src lib_tinymaix)
 
-
-include_directories( . ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
-
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 #set(LIB_INFER ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libtinymaix.a)
 
-add_executable(${TARGET_NAME} main.c ${lib_tinymaix} )  
-target_link_libraries(${TARGET_NAME} -lm )   
+add_executable(${PROJECT_NAME} main.c ${lib_tinymaix})
+target_link_libraries(${PROJECT_NAME} -lm)

--- a/include/tm_port.h
+++ b/include/tm_port.h
@@ -19,6 +19,7 @@ limitations under the License.
 #define TM_ARCH_ARM_MVEI    (3) //ARMv8.1: M55, etc.
 #define TM_ARCH_RV32P       (4) //T-head E907, etc.
 #define TM_ARCH_RV64V       (5) //T-head C906,C910, etc.
+#define TM_ARCH_CUDA        (6) //Nvidia GPU, Jetson, etc.
 
 #define TM_OPT0             (0) //default, least code and buf
 #define TM_OPT1             (1) //opt for speed, need more code and buf
@@ -37,6 +38,7 @@ limitations under the License.
 
 
 #define TM_INLINE       __attribute__((always_inline)) static inline
+#define TM_WEAK         __attribute__((weak))
 #define tm_malloc(x)    malloc(x)
 #define tm_free(x)      free(x)
 

--- a/include/tm_port.h
+++ b/include/tm_port.h
@@ -19,7 +19,6 @@ limitations under the License.
 #define TM_ARCH_ARM_MVEI    (3) //ARMv8.1: M55, etc.
 #define TM_ARCH_RV32P       (4) //T-head E907, etc.
 #define TM_ARCH_RV64V       (5) //T-head C906,C910, etc.
-#define TM_ARCH_CUDA        (6) //Nvidia GPU, Jetson, etc.
 
 #define TM_OPT0             (0) //default, least code and buf
 #define TM_OPT1             (1) //opt for speed, need more code and buf

--- a/src/tm_model.c
+++ b/src/tm_model.c
@@ -14,13 +14,13 @@ limitations under the License.
 //load model
 //mdl: model handle; bin: model bin buf; buf: main buf for middle output; cb: layer callback; 
 //in: return input mat, include buf addr; //you can ignore it if use static buf
-tm_err_t __attribute__((weak)) tm_load  (tm_mdl_t* mdl, const uint8_t* bin, uint8_t*buf, tm_cb_t cb, tm_mat_t* in)
+tm_err_t TM_WEAK tm_load  (tm_mdl_t* mdl, const uint8_t* bin, uint8_t*buf, tm_cb_t cb, tm_mat_t* in)
 {
     tm_mdlbin_t* mdl_bin = (tm_mdlbin_t*)bin;
     if(mdl_bin->magic != TM_MDL_MAGIC)   return TM_ERR_MAGIC;   //FIXME: big-endian not compatible
     if(mdl_bin->mdl_type != TM_MDL_TYPE) return TM_ERR_MDLTYPE;
     mdl->b          = mdl_bin;
-    mdl->cb         = (void*)cb; 
+    mdl->cb         = (void*)cb;
     if(buf == NULL) {
         mdl->buf        = (uint8_t*)tm_malloc(mdl->b->buf_size);
         if(mdl->buf == NULL) return TM_ERR_OOM;
@@ -41,7 +41,7 @@ tm_err_t __attribute__((weak)) tm_load  (tm_mdl_t* mdl, const uint8_t* bin, uint
 }
 
 //remove model
-void __attribute__((weak)) tm_unload(tm_mdl_t* mdl)               
+void TM_WEAK tm_unload(tm_mdl_t* mdl)
 {
     if(mdl->main_alloc) tm_free(mdl->buf);
     if(mdl->subbuf) tm_free(mdl->subbuf);
@@ -49,7 +49,7 @@ void __attribute__((weak)) tm_unload(tm_mdl_t* mdl)
 }
 
 //preprocess data input
-tm_err_t __attribute__((weak)) tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_mat_t* in, tm_mat_t* out)
+tm_err_t TM_WEAK tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_mat_t* in, tm_mat_t* out)
 {
     tml_head_t* l0h = (tml_head_t*)mdl->b->layers_body;
     sctype_t in_s = l0h->in_s;
@@ -68,7 +68,7 @@ tm_err_t __attribute__((weak)) tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_
 #else
     case TMPP_UINT2FP01:
         for(int i=0; i<in_size; i++)
-            out->data[i] = (((uint8_t*)(in->data))[i])/255.0; 
+            out->data[i] = (((uint8_t*)(in->data))[i])/255.0;
         break;
     case TMPP_UINT2FPN11:
         for(int i=0; i<in_size; i++)
@@ -85,7 +85,7 @@ tm_err_t __attribute__((weak)) tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_
 
 //run model
 //mdl: model handle; in: input mat; out: output mat
-tm_err_t __attribute__((weak)) tm_run(tm_mdl_t* mdl, tm_mat_t* in, tm_mat_t* out)
+tm_err_t TM_WEAK tm_run(tm_mdl_t* mdl, tm_mat_t* in, tm_mat_t* out)
 {
     tm_mat_t _in, _out;
     tm_err_t res = TM_OK;


### PR DESCRIPTION
1. For some platforms, using `__attribute__((weak))` will result in failure to link, here is managed by tm_port
```c
#define TM_WEAK         __attribute__((weak))
```

2. Standardize CMake
- add `cmake_minimum_required(VERSION 3.1)`
- use `project()` instead of `set(TARGET_NAME "")`
