### PR TITLE
Optimize int8 for C906

### DIFF
--- a/src/arch_arm_mvei.h
+++ b/src/arch_arm_mvei.h
@@ -106,3 +106,68 @@ TM_INLINE void tm_dot_prod_3x3x1(mtype_t* sptr, mtype_t* kptr, sumtype_t* result
 #else
     #error "TODO"
 #endif
+
+#if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
+
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, \
+    sctype_t* scales, sctype_t out_s, zptype_t out_zp)
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+        case TM_ACT_RELU6: //treat relu6 as relu in float mode //speed up
+            sum = sum>0?sum:0;
+            break;
+        //    sum = sum>0?sum:0;
+        //    sum = sum>6?6:sum;
+        //    break;
+        default:
+            break;
+        }
+        outp[i] = (mtype_t)sum;
+    }
+    return;
+}
+
+#elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
+
+#if !TM_FASTSCALE
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, sctype_t* scales, sctype_t out_s_inv, zptype_t out_zp)
+#else
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, int32_t* scales, int32_t out_s, zptype_t out_zp)
+#endif
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        #if !TM_FASTSCALE
+            float sumf = sum*scales[i];
+        #else 
+            sumtype_t sumf = (sum<<TM_FASTSCALE_SHIFT)/scales[i];
+        #endif
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+            sumf = sumf>0?sumf:0;
+            break;
+        case TM_ACT_RELU6:
+            sumf = sumf>0?sumf:0;
+        #if (!TM_FASTSCALE)
+            sumf = sumf>6?6:sumf;
+        #else
+            sumf = sumf>(6<<TM_FASTSCALE_SHIFT)?(6<<TM_FASTSCALE_SHIFT):sumf;
+        #endif
+            break;
+        default:
+            break;
+        }
+        #if !TM_FASTSCALE
+            outp[i] = (mtype_t)(sumf*out_s_inv + out_zp);  //(mtype_t)((int)(sumf/out_s) + out_zp) //(mtype_t)((int)(sumf/out_s +0.5) + out_zp)
+        #else 
+            outp[i] = (mtype_t)(((sumf*out_s)>>(TM_FASTSCALE_SHIFT+TM_FASTSCALE_SHIFT))+out_zp);
+        #endif
+    }
+    return;
+}
+#endif

--- a/src/arch_arm_neon.h
+++ b/src/arch_arm_neon.h
@@ -208,3 +208,68 @@ TM_INLINE void tm_dot_prod_3x3x1(mtype_t* sptr, mtype_t* kptr, sumtype_t* result
 #else  
     #error "TODO"
 #endif
+
+#if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
+
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, \
+    sctype_t* scales, sctype_t out_s, zptype_t out_zp)
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+        case TM_ACT_RELU6: //treat relu6 as relu in float mode //speed up
+            sum = sum>0?sum:0;
+            break;
+        //    sum = sum>0?sum:0;
+        //    sum = sum>6?6:sum;
+        //    break;
+        default:
+            break;
+        }
+        outp[i] = (mtype_t)sum;
+    }
+    return;
+}
+
+#elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
+
+#if !TM_FASTSCALE
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, sctype_t* scales, sctype_t out_s_inv, zptype_t out_zp)
+#else
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, int32_t* scales, int32_t out_s, zptype_t out_zp)
+#endif
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        #if !TM_FASTSCALE
+            float sumf = sum*scales[i];
+        #else 
+            sumtype_t sumf = (sum<<TM_FASTSCALE_SHIFT)/scales[i];
+        #endif
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+            sumf = sumf>0?sumf:0;
+            break;
+        case TM_ACT_RELU6:
+            sumf = sumf>0?sumf:0;
+        #if (!TM_FASTSCALE)
+            sumf = sumf>6?6:sumf;
+        #else
+            sumf = sumf>(6<<TM_FASTSCALE_SHIFT)?(6<<TM_FASTSCALE_SHIFT):sumf;
+        #endif
+            break;
+        default:
+            break;
+        }
+        #if !TM_FASTSCALE
+            outp[i] = (mtype_t)(sumf*out_s_inv + out_zp);  //(mtype_t)((int)(sumf/out_s) + out_zp) //(mtype_t)((int)(sumf/out_s +0.5) + out_zp)
+        #else 
+            outp[i] = (mtype_t)(((sumf*out_s)>>(TM_FASTSCALE_SHIFT+TM_FASTSCALE_SHIFT))+out_zp);
+        #endif
+    }
+    return;
+}
+#endif

--- a/src/arch_arm_simd.h
+++ b/src/arch_arm_simd.h
@@ -120,3 +120,68 @@ TM_INLINE void tm_dot_prod_3x3x1(mtype_t* sptr, mtype_t* kptr, sumtype_t* result
         sptr[6]*kptr[6] + sptr[7]*kptr[7] + sptr[8]*kptr[8] ;
     return;
 }
+
+#if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
+
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, \
+    sctype_t* scales, sctype_t out_s, zptype_t out_zp)
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+        case TM_ACT_RELU6: //treat relu6 as relu in float mode //speed up
+            sum = sum>0?sum:0;
+            break;
+        //    sum = sum>0?sum:0;
+        //    sum = sum>6?6:sum;
+        //    break;
+        default:
+            break;
+        }
+        outp[i] = (mtype_t)sum;
+    }
+    return;
+}
+
+#elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
+
+#if !TM_FASTSCALE
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, sctype_t* scales, sctype_t out_s_inv, zptype_t out_zp)
+#else
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, int32_t* scales, int32_t out_s, zptype_t out_zp)
+#endif
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        #if !TM_FASTSCALE
+            float sumf = sum*scales[i];
+        #else 
+            sumtype_t sumf = (sum<<TM_FASTSCALE_SHIFT)/scales[i];
+        #endif
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+            sumf = sumf>0?sumf:0;
+            break;
+        case TM_ACT_RELU6:
+            sumf = sumf>0?sumf:0;
+        #if (!TM_FASTSCALE)
+            sumf = sumf>6?6:sumf;
+        #else
+            sumf = sumf>(6<<TM_FASTSCALE_SHIFT)?(6<<TM_FASTSCALE_SHIFT):sumf;
+        #endif
+            break;
+        default:
+            break;
+        }
+        #if !TM_FASTSCALE
+            outp[i] = (mtype_t)(sumf*out_s_inv + out_zp);  //(mtype_t)((int)(sumf/out_s) + out_zp) //(mtype_t)((int)(sumf/out_s +0.5) + out_zp)
+        #else 
+            outp[i] = (mtype_t)(((sumf*out_s)>>(TM_FASTSCALE_SHIFT+TM_FASTSCALE_SHIFT))+out_zp);
+        #endif
+    }
+    return;
+}
+#endif

--- a/src/arch_cpu.h
+++ b/src/arch_cpu.h
@@ -128,4 +128,67 @@ TM_INLINE void l_postprocess_sum(sumtype_t sum, btype_t b, int act, mtype_t* out
 
 #endif
 
+#if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
 
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, \
+    sctype_t* scales, sctype_t out_s, zptype_t out_zp)
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+        case TM_ACT_RELU6: //treat relu6 as relu in float mode //speed up
+            sum = sum>0?sum:0;
+            break;
+        //    sum = sum>0?sum:0;
+        //    sum = sum>6?6:sum;
+        //    break;
+        default:
+            break;
+        }
+        outp[i] = (mtype_t)sum;
+    }
+    return;
+}
+
+#elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
+
+#if !TM_FASTSCALE
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, sctype_t* scales, sctype_t out_s_inv, zptype_t out_zp)
+#else
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, int32_t* scales, int32_t out_s, zptype_t out_zp)
+#endif
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        #if !TM_FASTSCALE
+            float sumf = sum*scales[i];
+        #else 
+            sumtype_t sumf = (sum<<TM_FASTSCALE_SHIFT)/scales[i];
+        #endif
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+            sumf = sumf>0?sumf:0;
+            break;
+        case TM_ACT_RELU6:
+            sumf = sumf>0?sumf:0;
+        #if (!TM_FASTSCALE)
+            sumf = sumf>6?6:sumf;
+        #else
+            sumf = sumf>(6<<TM_FASTSCALE_SHIFT)?(6<<TM_FASTSCALE_SHIFT):sumf;
+        #endif
+            break;
+        default:
+            break;
+        }
+        #if !TM_FASTSCALE
+            outp[i] = (mtype_t)(sumf*out_s_inv + out_zp);  //(mtype_t)((int)(sumf/out_s) + out_zp) //(mtype_t)((int)(sumf/out_s +0.5) + out_zp)
+        #else 
+            outp[i] = (mtype_t)(((sumf*out_s)>>(TM_FASTSCALE_SHIFT+TM_FASTSCALE_SHIFT))+out_zp);
+        #endif
+    }
+    return;
+}
+#endif

--- a/src/arch_cskyv2.h
+++ b/src/arch_cskyv2.h
@@ -152,4 +152,68 @@ TM_INLINE void l_postprocess_sum(sumtype_t sum, btype_t b, int act, mtype_t* out
 
 #endif
 
+#if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
+
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, \
+    sctype_t* scales, sctype_t out_s, zptype_t out_zp)
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+        case TM_ACT_RELU6: //treat relu6 as relu in float mode //speed up
+            sum = sum>0?sum:0;
+            break;
+        //    sum = sum>0?sum:0;
+        //    sum = sum>6?6:sum;
+        //    break;
+        default:
+            break;
+        }
+        outp[i] = (mtype_t)sum;
+    }
+    return;
+}
+
+#elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
+
+#if !TM_FASTSCALE
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, sctype_t* scales, sctype_t out_s_inv, zptype_t out_zp)
+#else
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, int32_t* scales, int32_t out_s, zptype_t out_zp)
+#endif
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        #if !TM_FASTSCALE
+            float sumf = sum*scales[i];
+        #else 
+            sumtype_t sumf = (sum<<TM_FASTSCALE_SHIFT)/scales[i];
+        #endif
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+            sumf = sumf>0?sumf:0;
+            break;
+        case TM_ACT_RELU6:
+            sumf = sumf>0?sumf:0;
+        #if (!TM_FASTSCALE)
+            sumf = sumf>6?6:sumf;
+        #else
+            sumf = sumf>(6<<TM_FASTSCALE_SHIFT)?(6<<TM_FASTSCALE_SHIFT):sumf;
+        #endif
+            break;
+        default:
+            break;
+        }
+        #if !TM_FASTSCALE
+            outp[i] = (mtype_t)(sumf*out_s_inv + out_zp);  //(mtype_t)((int)(sumf/out_s) + out_zp) //(mtype_t)((int)(sumf/out_s +0.5) + out_zp)
+        #else 
+            outp[i] = (mtype_t)(((sumf*out_s)>>(TM_FASTSCALE_SHIFT+TM_FASTSCALE_SHIFT))+out_zp);
+        #endif
+    }
+    return;
+}
+#endif
 

--- a/src/arch_rv32p.h
+++ b/src/arch_rv32p.h
@@ -183,3 +183,67 @@ TM_INLINE void tm_dot_prod_gap_3x3x1(mtype_t* sptr, mtype_t* kptr, uint32_t* k_o
 #else
 #error "RV32P opt for FP32 in not implement yet!"
 #endif
+#if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
+
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, \
+    sctype_t* scales, sctype_t out_s, zptype_t out_zp)
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+        case TM_ACT_RELU6: //treat relu6 as relu in float mode //speed up
+            sum = sum>0?sum:0;
+            break;
+        //    sum = sum>0?sum:0;
+        //    sum = sum>6?6:sum;
+        //    break;
+        default:
+            break;
+        }
+        outp[i] = (mtype_t)sum;
+    }
+    return;
+}
+
+#elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
+
+#if !TM_FASTSCALE
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, sctype_t* scales, sctype_t out_s_inv, zptype_t out_zp)
+#else
+TM_INLINE void l_postprocess_sum(int n, sumtype_t* sums, btype_t* bs, int act, mtype_t* outp, int32_t* scales, int32_t out_s, zptype_t out_zp)
+#endif
+{
+    for(int i = 0; i < n; i++) {
+        sumtype_t sum = sums[i];
+        sum += bs[i];
+        #if !TM_FASTSCALE
+            float sumf = sum*scales[i];
+        #else 
+            sumtype_t sumf = (sum<<TM_FASTSCALE_SHIFT)/scales[i];
+        #endif
+        switch(act){    //activation func
+        case TM_ACT_RELU:
+            sumf = sumf>0?sumf:0;
+            break;
+        case TM_ACT_RELU6:
+            sumf = sumf>0?sumf:0;
+        #if (!TM_FASTSCALE)
+            sumf = sumf>6?6:sumf;
+        #else
+            sumf = sumf>(6<<TM_FASTSCALE_SHIFT)?(6<<TM_FASTSCALE_SHIFT):sumf;
+        #endif
+            break;
+        default:
+            break;
+        }
+        #if !TM_FASTSCALE
+            outp[i] = (mtype_t)(sumf*out_s_inv + out_zp);  //(mtype_t)((int)(sumf/out_s) + out_zp) //(mtype_t)((int)(sumf/out_s +0.5) + out_zp)
+        #else 
+            outp[i] = (mtype_t)(((sumf*out_s)>>(TM_FASTSCALE_SHIFT+TM_FASTSCALE_SHIFT))+out_zp);
+        #endif
+    }
+    return;
+}
+#endif

--- a/src/tm_layers_O1.c
+++ b/src/tm_layers_O1.c
@@ -48,13 +48,14 @@ TM_PERF_REG(t_sbuf);TM_PERF_REG(t_dotp);TM_PERF_REG(t_post);
 TM_PERF_REG(t_valid); TM_PERF_REG(t_pad); 
 TM_PERF_REG(t_conv); TM_PERF_REG(t_pwconv); TM_PERF_REG(t_dwconv); 
 
-#define BATCH_SIZE 16  //batch sum size
+#define BATCH_SIZE 8  //batch sum size
 /*************************** TML_CONV2D **********************************/
 static uint32_t k_oft[TM_MAX_KSIZE]; 
 static mtype_t sbuf[TM_MAX_KCSIZE]; 
 #if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
 #define SUMSCALE NULL
 static sctype_t outscale;
+#define OUTSCALE outscale
 
 #elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
 

--- a/src/tm_layers_O1.c
+++ b/src/tm_layers_O1.c
@@ -48,75 +48,27 @@ TM_PERF_REG(t_sbuf);TM_PERF_REG(t_dotp);TM_PERF_REG(t_post);
 TM_PERF_REG(t_valid); TM_PERF_REG(t_pad); 
 TM_PERF_REG(t_conv); TM_PERF_REG(t_pwconv); TM_PERF_REG(t_dwconv); 
 
-#define BATCH_SIZE 2  //batch sum size
+#define BATCH_SIZE 16  //batch sum size
 /*************************** TML_CONV2D **********************************/
 static uint32_t k_oft[TM_MAX_KSIZE]; 
 static mtype_t sbuf[TM_MAX_KCSIZE]; 
 #if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
-#define SUMSCALE (1.0)
+#define SUMSCALE NULL
 static sctype_t outscale;
-TM_INLINE void l_postprocess_sum(sumtype_t sum, btype_t b, int act, mtype_t* outp, \
-    sctype_t scale, sctype_t out_s, zptype_t out_zp)
-{   sum += b;
-    switch(act){    //activation func
-    case TM_ACT_RELU:
-    case TM_ACT_RELU6: //treat relu6 as relu in float mode //speed up
-        sum = sum>0?sum:0;
-        break;
-    //    sum = sum>0?sum:0;
-    //    sum = sum>6?6:sum;
-    //    break;
-    default:
-        break;
-    }
-    *outp = (mtype_t)sum;
-    return;
-}
 
 #elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
 
 #if TM_FASTSCALE
     static int32_t sumscale[TM_MAX_CSIZE];
     static int32_t outscale;
+    #define OUTSCALE outscale
 #else
     static float sumscale[TM_MAX_CSIZE];
     static sctype_t outscale;
+    static sctype_t outscale_inv;
+    #define OUTSCALE outscale_inv
 #endif
-#define SUMSCALE (sumscale[c])
-
-#if !TM_FASTSCALE
-TM_INLINE void l_postprocess_sum(sumtype_t sum, btype_t b, int act, mtype_t* outp, sctype_t scale, sctype_t out_s, zptype_t out_zp)
-#else
-TM_INLINE void l_postprocess_sum(sumtype_t sum, btype_t b, int act, mtype_t* outp, int32_t scale, int32_t out_s, zptype_t out_zp)
-#endif
-{   sum += b;
-    #if !TM_FASTSCALE
-        float sumf = sum*scale;
-    #else 
-        sumtype_t sumf = (sum<<TM_FASTSCALE_SHIFT)/scale;
-    #endif
-    switch(act){    //activation func
-    case TM_ACT_RELU:
-        sumf = sumf>0?sumf:0;
-        break;
-    case TM_ACT_RELU6:
-        sumf = sumf>0?sumf:0;
-    #if (!TM_FASTSCALE)
-        sumf = sumf>6?6:sumf;
-    #else
-        sumf = sumf>(6<<TM_FASTSCALE_SHIFT)?(6<<TM_FASTSCALE_SHIFT):sumf;
-    #endif
-        break;
-    default:
-        break;
-    }
-    #if !TM_FASTSCALE
-        *outp = (mtype_t)(sumf/out_s + out_zp);  //(mtype_t)((int)(sumf/out_s) + out_zp) //(mtype_t)((int)(sumf/out_s +0.5) + out_zp)
-    #else 
-        *outp = (mtype_t)(((sumf*out_s)>>(TM_FASTSCALE_SHIFT+TM_FASTSCALE_SHIFT))+out_zp);
-    #endif
-    return;
-}
+#define SUMSCALE (sumscale + c)
 #endif
  
 //1x1 pw conv
@@ -140,14 +92,16 @@ TM_INLINE tm_err_t l_tml_pwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype
             
             int c = 0;
             for(; c<out->c-BATCH_SIZE+1; ){
-                tm_dot_prod_pack2(sptr, kptr, chi, sums);
-                l_postprocess_sum(sums[0], b[c], act, outp, SUMSCALE, outscale, out_zp); c++; outp++;
-                l_postprocess_sum(sums[1], b[c], act, outp, SUMSCALE, outscale, out_zp); c++; outp++;
+                for(int bat = 0; bat < BATCH_SIZE; bat+=2)
+                    tm_dot_prod_pack2(sptr, kptr + chi*bat, chi, sums + bat);
+                l_postprocess_sum(BATCH_SIZE, sums, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp);
+                c += BATCH_SIZE;
+                outp += BATCH_SIZE;
                 kptr += chi*BATCH_SIZE;//*2;
             }
             for(; c<out->c; c++){
                 tm_dot_prod(sptr, kptr, chi, &sum); //size=maxk*chi //pw maxk==1
-                l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                 kptr += chi;
             }
         }
@@ -229,14 +183,16 @@ TM_INLINE tm_err_t l_tml_conv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype_t
             int c = 0;
             wtype_t* kptr = (wtype_t*)w;
             for(; c<out->c-BATCH_SIZE+1; ){
-                tm_dot_prod_pack2(sptr, kptr, maxk*chi, sums);
-                l_postprocess_sum(sums[0], b[c], act, outp, SUMSCALE, outscale, out_zp); c++; outp++;
-                l_postprocess_sum(sums[1], b[c], act, outp, SUMSCALE, outscale, out_zp); c++; outp++;
+                for(int bat = 0; bat < BATCH_SIZE; bat+=2)
+                    tm_dot_prod_pack2(sptr, kptr + chi*maxk*bat, maxk*chi, sums + bat);
+                l_postprocess_sum(BATCH_SIZE, sums, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp);
+                c += BATCH_SIZE;
+                outp += BATCH_SIZE;
                 kptr += chi*maxk*BATCH_SIZE;
             }
             for(; c<out->c; c++){
                 tm_dot_prod(sptr, kptr, maxk*chi, &sum); 
-                l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                 kptr += chi*maxk;
             }
         }
@@ -282,7 +238,7 @@ TM_INLINE tm_err_t l_tml_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype
                     for (int c = 0; c < cho; c++) {
                         wtype_t* kptr = (wtype_t*)w + c*9;
                         tm_dot_prod_gap_3x3x1(sptr, kptr, k_oft, &sum);
-                        l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                        l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                         sptr += 1;
                     }
                 } else {
@@ -300,7 +256,7 @@ TM_INLINE tm_err_t l_tml_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype
                         wtype_t* kptr = (wtype_t*)w + c*maxk;
                         tm_dot_prod(sptr, kptr, maxk, &sum);
                         //sum = sptr[0]*kptr[0] + sptr[1]*kptr[1] + sptr[2]*kptr[2] + sptr[3]*kptr[3] + sptr[4]*kptr[4] + sptr[5]*kptr[5] + sptr[6]*kptr[6] + sptr[7]*kptr[7] + sptr[8]*kptr[8] ;
-                        l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                        l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                         sptr += maxk; //dwconv need move step
                     }
                 }
@@ -335,14 +291,14 @@ TM_INLINE tm_err_t l_tml_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype
                     for (int c = 0; c < cho; c++) {
                         wtype_t* kptr = (wtype_t*)w + c*9;
                         tm_dot_prod_3x3x1(sptr, kptr, &sum);
-                        l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                        l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                         sptr += maxk;
                     }
                 } else { 
                     for(int c=0; c<out->c; c++){
                         wtype_t* kptr = (wtype_t*)w + c*maxk;
                         tm_dot_prod(sptr, kptr, maxk, &sum);
-                        l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                        l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                         sptr += maxk; //dwconv need move step
                     }
                 }
@@ -390,7 +346,7 @@ TM_INLINE tm_err_t l_tml_dwconv2d_3x3_part(tm_mat_t* in, tm_mat_t* out, wtype_t*
                 for (int c = 0; c < cho; c++) {
                     wtype_t* kptr = (wtype_t*)w + c*9;
                     tm_dot_prod_gap_3x3x1(sptr, kptr, k_oft, &sum);
-                    l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                    l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                     sptr += 1;
                 }
             } else {        //same pad part
@@ -424,7 +380,7 @@ TM_INLINE tm_err_t l_tml_dwconv2d_3x3_part(tm_mat_t* in, tm_mat_t* out, wtype_t*
                 for (int c = 0; c < cho; c++) {
                     wtype_t* kptr = (wtype_t*)w + c*9;
                     tm_dot_prod_3x3x1(sptr, kptr, &sum);
-                    l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                    l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                     sptr += maxk;
                 }
             }
@@ -503,10 +459,10 @@ TM_INLINE tm_err_t l_tml_dwconv2d_3x3_nostride(tm_mat_t* in, tm_mat_t* out, wtyp
                     sum3 = sptr[dw_koft[5]]*kptr[0] + sptr[dw_koft[6]]*kptr[1] + sptr[dw_koft[7]]*kptr[2] + \
                         sptr[dw_koft[9]]*kptr[3] + sptr[dw_koft[10]]*kptr[4] + sptr[dw_koft[11]]*kptr[5] + \
                         sptr[dw_koft[13]]*kptr[6] + sptr[dw_koft[14]]*kptr[7] + sptr[dw_koft[15]]*kptr[8] ;
-                    l_postprocess_sum(sum0, b[c], act, outp+0*cho, SUMSCALE, outscale, out_zp); 
-                    l_postprocess_sum(sum1, b[c], act, outp+1*cho, SUMSCALE, outscale, out_zp); 
-                    l_postprocess_sum(sum2, b[c], act, outp+(out->w+0)*cho, SUMSCALE, outscale, out_zp); 
-                    l_postprocess_sum(sum3, b[c], act, outp+(out->w+1)*cho, SUMSCALE, outscale, out_zp); 
+                    l_postprocess_sum(1, &sum0, b + c, act, outp+0*cho, SUMSCALE, OUTSCALE, out_zp); 
+                    l_postprocess_sum(1, &sum1, b + c, act, outp+1*cho, SUMSCALE, OUTSCALE, out_zp); 
+                    l_postprocess_sum(1, &sum2, b + c, act, outp+(out->w+0)*cho, SUMSCALE, OUTSCALE, out_zp); 
+                    l_postprocess_sum(1, &sum3, b + c, act, outp+(out->w+1)*cho, SUMSCALE, OUTSCALE, out_zp); 
                     outp ++;
                     sptr ++;
                 }
@@ -542,7 +498,7 @@ TM_INLINE tm_err_t l_tml_dwconv2d_3x3_nostride(tm_mat_t* in, tm_mat_t* out, wtyp
                 for(int c=0; c<out->c; c++){
                     wtype_t* kptr = (wtype_t*)w + c*maxk;
                     //tm_dot_prod(sptr, kptr, maxk, &sum);TM_PERF_ADD(t_dotp);
-                    //l_postprocess_sum(sum, b[c], act, outp+0*cho, SUMSCALE, outscale, out_zp); 
+                    //l_postprocess_sum(sum, b[c], act, outp+0*cho, SUMSCALE, OUTSCALE, out_zp); 
                     sum0 = sptr[0]*kptr[0] + sptr[1]*kptr[1] + sptr[2]*kptr[2] + \
                         sptr[4]*kptr[3] + sptr[5]*kptr[4] + sptr[6]*kptr[5] + \
                         sptr[8]*kptr[6] + sptr[9]*kptr[7] + sptr[10]*kptr[8] ;
@@ -555,10 +511,10 @@ TM_INLINE tm_err_t l_tml_dwconv2d_3x3_nostride(tm_mat_t* in, tm_mat_t* out, wtyp
                     sum3 = sptr[5]*kptr[0] + sptr[6]*kptr[1] + sptr[7]*kptr[2] + \
                         sptr[9]*kptr[3] + sptr[10]*kptr[4] + sptr[11]*kptr[5] + \
                         sptr[13]*kptr[6] + sptr[14]*kptr[7] + sptr[15]*kptr[8] ;
-                    l_postprocess_sum(sum0, b[c], act, outp+0*cho, SUMSCALE, outscale, out_zp); 
-                    l_postprocess_sum(sum1, b[c], act, outp+1*cho, SUMSCALE, outscale, out_zp); 
-                    l_postprocess_sum(sum2, b[c], act, outp+(out->w+0)*cho, SUMSCALE, outscale, out_zp); 
-                    l_postprocess_sum(sum3, b[c], act, outp+(out->w+1)*cho, SUMSCALE, outscale, out_zp); 
+                    l_postprocess_sum(1, &sum0, b + c, act, outp+0*cho, SUMSCALE, OUTSCALE, out_zp); 
+                    l_postprocess_sum(1, &sum1, b + c, act, outp+1*cho, SUMSCALE, OUTSCALE, out_zp); 
+                    l_postprocess_sum(1, &sum2, b + c, act, outp+(out->w+0)*cho, SUMSCALE, OUTSCALE, out_zp); 
+                    l_postprocess_sum(1, &sum3, b + c, act, outp+(out->w+1)*cho, SUMSCALE, OUTSCALE, out_zp); 
                     //printf("==%.1f,%.1f,%.1f,%.1f\r\n", out->data[0], out->data[1], out->data[2], out->data[3]);
                     sptr += maxk_blk; //dwconv need move step
                     outp++;
@@ -658,7 +614,7 @@ TM_INLINE tm_err_t l_tml_mdwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btyp
                 sum = 0;
                 wtype_t* kptr = (wtype_t*)w + c*maxk;
                 tm_dot_prod(sptr, kptr, maxk, &sum);
-                l_postprocess_sum(sum, b[c], act, outp, SUMSCALE, outscale, out_zp); outp++;
+                l_postprocess_sum(1, &sum, b + c, act, outp, SUMSCALE, OUTSCALE, out_zp); outp++;
                 sptr += maxk; //dwconv need move step
             }
         }
@@ -685,6 +641,7 @@ tm_err_t tml_conv2d_dwconv2d(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype_t* b
         for(int c=0; c<out->c;c++) sumscale[c]=1.0/ws[c]/in_s;
     #else
         outscale = out_s;
+        outscale_inv = 1.f / outscale;
         for(int c=0; c<out->c;c++) sumscale[c]=ws[c]*in_s;
     #endif
     #else


### PR DESCRIPTION
- [x] Add support for any `BATCH_SIZE` (pow of 2)
- [x] Move `l_postprocess_sum` to `arch_x.h`
- [x] Add `n` parameter to `l_postprocess_sum` for vectorize
- [x] Optimize int8 `tm_dot_prod_pack2` for C906
- [x] Optimize int8/fp16 `l_postprocess_sum` for C906

Benchmark:

TM_MDL_INT8 (ms)

| config | vww96  | mbnet128 |
| ------ | ----- | ----- |
| O1 RV64V | 29.320 -> 25.6 (fps +14.5%) | 58.957 -> 37.8 (fps +56%) |
