### PR TITLE
Fix TM_GET_US overflow issue

### DIFF
--- a/include/tm_port.h
+++ b/include/tm_port.h
@@ -50,7 +50,7 @@ limitations under the License.
 /******************************* DBG TIME CONFIG  ************************************/
 #include <sys/time.h>
 #include <time.h>
-#define  TM_GET_US()       ((uint32_t)(clock()*1000000/CLOCKS_PER_SEC))
+#define  TM_GET_US()       ((uint32_t)((uint64_t)clock()*1000000/CLOCKS_PER_SEC))
 
 #define TM_DBGT_INIT()     uint32_t _start,_finish;float _time;_start=TM_GET_US();
 #define TM_DBGT_START()    _start=TM_GET_US();


### PR DESCRIPTION
clock() return value should be converted to uint64_t to avoid overflow.

I have met overflow issue to get _start and _finish value,

_finish < _start, which is not correct

