### PR TITLE
tflite_reader: Fix compatibility with Tensorflow 2.14 etc

### DIFF
--- a/tools/tflite_reader.py
+++ b/tools/tflite_reader.py
@@ -22,7 +22,6 @@ from tensorflow.keras.layers import Conv2D, Dense, MaxPooling2D, Softmax, Activa
 from tensorflow.keras.layers import MaxPool2D, AvgPool2D, AveragePooling2D, GlobalAveragePooling2D,ZeroPadding2D,Input,Embedding,PReLU
 from keras.callbacks import ModelCheckpoint
 from keras.callbacks import TensorBoard
-from keras.utils import np_utils
 from keras.preprocessing.image import ImageDataGenerator
 import keras.backend as K
 import tensorflow as tf


### PR DESCRIPTION
Code is trying to import a submodule which has been removed. But the code is not even used.
With this fix, I can use the model conversion tools with tensorflow / keras 2.14 (the last version before Keras 3.x).