### PR TITLE
Allow to disable "static" using TM_STATIC macro

### DIFF
--- a/include/tinymaix.h
+++ b/include/tinymaix.h
@@ -26,6 +26,11 @@ limitations under the License.
 #define  TM_MDL_FP8_152 5 //experimental
 #include "tm_port.h"
 
+#ifndef TM_STATIC
+// Set default value, if not defined in tm_port.h
+#define TM_STATIC static
+#endif
+
 /******************************* MARCO ************************************/
 #define TM_MDL_MAGIC 'XIAM'     //mdl magic sign
 #define TM_ALIGN_SIZE   (8)     //8 byte align

--- a/src/arch_rv64v.h
+++ b/src/arch_rv64v.h
@@ -279,7 +279,7 @@ TM_INLINE void tm_dot_prod_3x3x1(mtype_t* sptr, mtype_t* kptr, sumtype_t* result
 //Vector Widening Integer Multiply-Add Operations
 //  vint32m4_t vwmacc_vv_i32m4 (vint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl);
 uint32_t tdot = 0;
-static uint32_t size0=0;
+TM_STATIC uint32_t size0=0;
 TM_INLINE  void tm_dot_prod(mtype_t* sptr, mtype_t* kptr,uint32_t size, sumtype_t* result)
 { 
     int32_t sumbuf[PACK_N];

--- a/src/tm_layers.c
+++ b/src/tm_layers.c
@@ -42,8 +42,8 @@ TM_PERF_REG(t_valid); TM_PERF_REG(t_pad);
 TM_PERF_REG(t_conv); TM_PERF_REG(t_pwconv); TM_PERF_REG(t_dwconv); 
 
 /*************************** TML_CONV2D **********************************/
-static uint32_t k_oft[TM_MAX_KSIZE]; 
-static mtype_t sbuf[TM_MAX_KCSIZE]; 
+TM_STATIC uint32_t k_oft[TM_MAX_KSIZE]; 
+TM_STATIC mtype_t sbuf[TM_MAX_KCSIZE]; 
 #if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
 #define SUMSCALE NULL
 #define OUTSCALE outscale
@@ -51,10 +51,10 @@ static mtype_t sbuf[TM_MAX_KCSIZE];
 #elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
 
 #if TM_FASTSCALE
-    static int32_t sumscale[TM_MAX_CSIZE];
+    TM_STATIC int32_t sumscale[TM_MAX_CSIZE];
     #define OUTSCALE outscale
 #else
-    static float sumscale[TM_MAX_CSIZE];
+    TM_STATIC float sumscale[TM_MAX_CSIZE];
     #define OUTSCALE outscale_inv
 #endif
 #define SUMSCALE (sumscale + c)

--- a/src/tm_layers_O1.c
+++ b/src/tm_layers_O1.c
@@ -52,23 +52,23 @@ TM_PERF_REG(t_conv); TM_PERF_REG(t_pwconv); TM_PERF_REG(t_dwconv);
 
 #define BATCH_SIZE 8  //batch sum size
 /*************************** TML_CONV2D **********************************/
-static uint32_t k_oft[TM_MAX_KSIZE]; 
-static mtype_t sbuf[TM_MAX_KCSIZE]; 
+TM_STATIC uint32_t k_oft[TM_MAX_KSIZE]; 
+TM_STATIC mtype_t sbuf[TM_MAX_KCSIZE]; 
 #if (TM_MDL_TYPE==TM_MDL_FP32) || (TM_MDL_TYPE==TM_MDL_FP16) 
 #define SUMSCALE NULL
-static sctype_t outscale;
+TM_STATIC sctype_t outscale;
 #define OUTSCALE outscale
 
 #elif (TM_MDL_TYPE==TM_MDL_INT8) || (TM_MDL_TYPE==TM_MDL_INT16) 
 
 #if TM_FASTSCALE
-    static int32_t sumscale[TM_MAX_CSIZE];
-    static int32_t outscale;
+    TM_STATIC int32_t sumscale[TM_MAX_CSIZE];
+    TM_STATIC int32_t outscale;
     #define OUTSCALE outscale
 #else
-    static float sumscale[TM_MAX_CSIZE];
-    static sctype_t outscale;
-    static sctype_t outscale_inv;
+    TM_STATIC float sumscale[TM_MAX_CSIZE];
+    TM_STATIC sctype_t outscale;
+    TM_STATIC sctype_t outscale_inv;
     #define OUTSCALE outscale_inv
 #endif
 #define SUMSCALE (sumscale + c)
@@ -397,8 +397,8 @@ TM_INLINE tm_err_t l_tml_dwconv2d_3x3_part(tm_mat_t* in, tm_mat_t* out, wtype_t*
 #define CONV_BLK_H (4) 
 #define CONV_BLK_STEPX (CONV_BLK_W-3+1)
 #define CONV_BLK_STEPY (CONV_BLK_H-3+1)
-static mtype_t dw_sbuf[CONV_BLK_W*CONV_BLK_H*TM_MAX_CSIZE];
-static uint32_t dw_koft[CONV_BLK_W*CONV_BLK_H];
+TM_STATIC mtype_t dw_sbuf[CONV_BLK_W*CONV_BLK_H*TM_MAX_CSIZE];
+TM_STATIC uint32_t dw_koft[CONV_BLK_W*CONV_BLK_H];
 
 // 40ms->27ms
 TM_INLINE tm_err_t l_tml_dwconv2d_3x3_nostride(tm_mat_t* in, tm_mat_t* out, wtype_t* w, btype_t* b, \


### PR DESCRIPTION
Not supported on all platforms/ports. Specifically the mpy_ld.py linker for MicroPython dynamic native modules. Fixes #75