### PR TITLE
Avoid double precision operations

### DIFF
--- a/src/tm_layers.c
+++ b/src/tm_layers.c
@@ -261,7 +261,7 @@ tm_err_t TM_WEAK tml_softmax(tm_mat_t* in, tm_mat_t* out, sctype_t in_s, zptype_
         dout[c] -= dmax;
         dout[c] = (float)tm_exp(dout[c]);
         sum     += dout[c];
-        dout[c] -= 0.000001;  //prevent 1.0 value (cause 256 overflow)
+        dout[c] -= 0.000001f;  //prevent 1.0 value (cause 256 overflow)
     }
     for(int c=0; c <in->c; c++){  //int8/int16 <= fp32, so it is ok
     #if TM_MDL_TYPE == TM_MDL_INT8 || TM_MDL_TYPE == TM_MDL_INT16

--- a/src/tm_model.c
+++ b/src/tm_model.c
@@ -67,11 +67,11 @@ tm_err_t TM_WEAK tm_preprocess(tm_mdl_t* mdl, tm_pp_t pp_type, tm_mat_t* in, tm_
 #else
     case TMPP_UINT2FP01:
         for(int i=0; i<in_size; i++)
-            out->data[i] = (((uint8_t*)(in->data))[i])/255.0;
+            out->data[i] = (((uint8_t*)(in->data))[i])/255.0f;
         break;
     case TMPP_UINT2FPN11:
         for(int i=0; i<in_size; i++)
-            out->data[i] = ((((uint8_t*)(in->data))[i])-128)/128.0;
+            out->data[i] = ((((uint8_t*)(in->data))[i])-128)/128.0f;
         break;
 #endif
     default:    //don't do anything


### PR DESCRIPTION
This was pulling in double precision math operations. The GCC option -Wdouble-promotion can be used to find these