### PR TITLE
Fix CI build due to ubuntu-latest change

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install OS dependencies
         run: |
-          sudo apt-get install -yqq python-tk git
+          sudo apt-get install -yqq python3-tk git
       - name: Install Python dependencies
         run: |
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION
Hi,
and thanks a lot for merging my recent MRs that added testing in CI using Github Actions.

When merged to master. Turns out that the "ubuntu-latest" GitHub Actions image recently changed from Ubuntu 22.04 to 24.04, and there was a small change in apt package names between those versions. This fixes that, and also locks the Ubuntu version so that similar does not happen in the future :)
